### PR TITLE
Handle cypress screenshots and videos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,3 +5,8 @@ workflows:
   build:
     jobs:
       - cypress/run
+          post-steps:
+            - store_artifacts:
+                path: cypress/videos
+            - store_artifacts:
+                path: cypress/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 workflows:
   build:
     jobs:
-      - cypress/run
+      - cypress/run:
           post-steps:
             - store_artifacts:
                 path: cypress/videos

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+cypress/videos
+cypress/screenshots


### PR DESCRIPTION
- Store screenshots and videos in CircleCI so we can more quickly see why tests failed and provide feedback.
- Add screenshots and videos to `.gitignore`. `cypress open` does not generate them but `cypress run` does (on the off chance that people use that command locally)